### PR TITLE
Add .ftp-deploy-ignore to exclude dev files from FTP deploy

### DIFF
--- a/.ftp-deploy-ignore
+++ b/.ftp-deploy-ignore
@@ -1,0 +1,31 @@
+# Ignore Git and GitHub metadata
+.git
+.github
+
+# Ignore node modules and lock files
+node_modules
+package.json
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Ignore common docs and config
+README.md
+LICENSE
+.gitignore
+.ftp-deploy-ignore
+
+# Ignore environment and log files
+.env
+.env.local
+.env.production
+.env.development
+*.log
+
+# Ignore workflow and CI files
+*.yml
+*.yaml
+
+# Ignore OS-specific files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Made an ignore file so that dev/private files wouldn't be uploaded to cpanel as part of the connecting github to godaddy.